### PR TITLE
Add Termux detection to setup script

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Detect Termux/Android environment
+if [[ "${PREFIX:-}" == */com.termux/* ]] || [[ "${OSTYPE:-}" == linux-android* ]]; then
+  pkg update
+  pkg install -y clang cmake make openssl git
+else
+  sudo apt-get update
+  sudo apt-get install -y build-essential cmake libssl-dev git
+fi


### PR DESCRIPTION
## Summary
- Detect Termux/Android via `$PREFIX` or `$OSTYPE`
- Install dependencies with `pkg` on Termux or `apt-get` on desktop Linux

## Testing
- `bash -n setup.sh`

------
https://chatgpt.com/codex/tasks/task_e_68c605700d5c8328aa75a8ca2c321ca6